### PR TITLE
feat: Implement low-priority issues #53-#62

### DIFF
--- a/i18n/en/webapps.ftl
+++ b/i18n/en/webapps.ftl
@@ -165,3 +165,36 @@ toggle-view=Toggle View
 
 # thumbnails (#48)
 fetch-thumbnail=Load Preview
+
+# privacy features (#53, #60, #61)
+content-blocking=Block Ads & Trackers
+block-third-party-cookies=Block Third-Party Cookies
+block-webrtc=Block WebRTC IP Leak
+
+# proxy (#54)
+proxy-url=Proxy URL
+proxy-url-placeholder=http://proxy.example.com:8080
+
+# zoom & session (#55, #56)
+zoom-level=Zoom Level
+zoom-level-placeholder=1.0
+restore-session=Restore Last Session
+
+# usage statistics (#57)
+launch-count=Launch Count
+last-launched=Last Launched
+never-launched=Never
+
+# minimize to background (#59)
+minimize-to-background=Minimize to Background on Close
+
+# auto dark mode (#62)
+auto-dark-mode=Auto Dark Mode
+
+# bulk operations (#58)
+bulk-select=Select
+bulk-done=Done
+bulk-delete=Delete Selected
+bulk-export=Export Selected
+toast-bulk-deleted=Selected apps deleted
+toast-bulk-exported=Selected apps exported

--- a/src/bin/webview.rs
+++ b/src/bin/webview.rs
@@ -81,6 +81,17 @@ fn main() -> wry::Result<()> {
     // which GTK uses as the WM_CLASS res_name on X11. This matches StartupWMClass
     // in the generated .desktop entry.
 
+    // #54: Set proxy environment variables if configured
+    if let Some(ref proxy) = browser.proxy_url {
+        if !proxy.trim().is_empty() {
+            // SAFETY: Called before any threads are spawned
+            unsafe {
+                std::env::set_var("http_proxy", proxy);
+                std::env::set_var("https_proxy", proxy);
+            }
+        }
+    }
+
     let mut context = WebContext::new(browser.profile);
 
     let mut builder = WebViewBuilder::new_with_web_context(&mut context)
@@ -198,6 +209,67 @@ fn main() -> wry::Result<()> {
         builder = builder.with_initialization_script(script);
     }
 
+    // #53: Content blocking (ads/trackers)
+    if let Some(true) = browser.content_blocking {
+        builder = builder.with_initialization_script(
+            r#"(function(){
+                var adSelectors = [
+                    'iframe[src*="ads"]', 'iframe[src*="doubleclick"]',
+                    'div[class*="ad-"]', 'div[class*="advert"]',
+                    'div[id*="google_ads"]', 'ins.adsbygoogle',
+                    '[data-ad]', '[data-ads]', '[data-ad-slot]'
+                ];
+                function removeAds() {
+                    adSelectors.forEach(function(sel) {
+                        document.querySelectorAll(sel).forEach(function(el) { el.remove(); });
+                    });
+                }
+                removeAds();
+                new MutationObserver(removeAds).observe(
+                    document.body || document.documentElement,
+                    { childList: true, subtree: true }
+                );
+            })()"#,
+        );
+    }
+
+    // #60: Block third-party cookies
+    if let Some(true) = browser.block_third_party_cookies {
+        builder = builder.with_initialization_script(
+            r#"(function(){
+                try {
+                    Object.defineProperty(document, 'cookie', {
+                        get: function() {
+                            return document._firstPartyCookies || '';
+                        },
+                        set: function(val) {
+                            // Only allow first-party cookie setting
+                            if (!val.includes('domain=') || val.includes(window.location.hostname)) {
+                                document._firstPartyCookies = val;
+                            }
+                        }
+                    });
+                } catch(e) {}
+            })()"#,
+        );
+    }
+
+    // #61: Block WebRTC IP leak
+    if let Some(true) = browser.block_webrtc {
+        builder = builder.with_initialization_script(
+            r#"(function(){
+                window.RTCPeerConnection = undefined;
+                window.webkitRTCPeerConnection = undefined;
+                window.mozRTCPeerConnection = undefined;
+                if (navigator.mediaDevices) {
+                    navigator.mediaDevices.enumerateDevices = function() {
+                        return Promise.resolve([]);
+                    };
+                }
+            })()"#,
+        );
+    }
+
     // Issue #39: Forward web notifications to COSMIC desktop notifications
     if perms.allow_notifications {
         builder = builder.with_initialization_script(
@@ -288,9 +360,11 @@ fn main() -> wry::Result<()> {
         })()"#,
     );
 
-    // Always set up IPC handler for media controls, badges, and optionally notifications
+    // Always set up IPC handler for media controls, badges, session URL, and optionally notifications
     let forward_notifications = perms.allow_notifications;
     let app_title = app_title_for_notifications.clone();
+    let restore_session_enabled = browser.restore_session.unwrap_or(false);
+    let ipc_app_id = browser.app_id.as_ref().to_string();
     builder = builder.with_ipc_handler(move |req| {
         let msg = req.body();
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(msg) {
@@ -317,6 +391,24 @@ fn main() -> wry::Result<()> {
                         tracing::debug!("Badge count: {count}");
                     }
                 }
+                Some("save_url") if restore_session_enabled => {
+                    if let Some(new_url) = parsed.get("url").and_then(|u| u.as_str()) {
+                        if !new_url.is_empty() {
+                            // Update last_url in the RON database
+                            let safe_id = webapps::browser::sanitize_app_id(&ipc_app_id);
+                            if let Some(db_path) = webapps::database_path(&format!("{safe_id}.ron")) {
+                                if let Ok(content) = std::fs::read_to_string(&db_path) {
+                                    if let Ok(mut launcher) = ron::from_str::<webapps::launcher::WebAppLauncher>(&content) {
+                                        launcher.browser.last_url = Some(new_url.to_string());
+                                        if let Ok(serialized) = ron::ser::to_string_pretty(&launcher, ron::ser::PrettyConfig::default()) {
+                                            let _ = std::fs::write(&db_path, serialized);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -339,6 +431,66 @@ fn main() -> wry::Result<()> {
         }
     }
 
+    // #55: Zoom level via CSS transform
+    if let Some(zoom) = browser.zoom_level {
+        if (zoom - 1.0).abs() > f64::EPSILON {
+            let zoom_clamped = zoom.clamp(0.25, 5.0);
+            builder = builder.with_initialization_script(&format!(
+                "(function(){{document.body.style.zoom='{}';}})()",
+                zoom_clamped
+            ));
+        }
+    }
+
+    // #56: Session restore — navigate to last URL if enabled
+    if let Some(true) = browser.restore_session {
+        if let Some(ref last) = browser.last_url {
+            if !last.is_empty() && is_url_safe(last) && last != &url {
+                builder = builder.with_url(last);
+            }
+        }
+    }
+
+    // #56: Session URL saving — periodically report current URL via IPC
+    if let Some(true) = browser.restore_session {
+        builder = builder.with_initialization_script(
+            r#"(function(){
+                setInterval(function() {
+                    window.ipc.postMessage(JSON.stringify({
+                        type: 'save_url',
+                        url: window.location.href
+                    }));
+                }, 30000);
+                // Also save on page unload
+                window.addEventListener('beforeunload', function() {
+                    window.ipc.postMessage(JSON.stringify({
+                        type: 'save_url',
+                        url: window.location.href
+                    }));
+                });
+            })()"#,
+        );
+    }
+
+    // #62: Auto dark mode CSS injection based on system preference
+    if let Some(true) = browser.auto_dark_mode {
+        builder = builder.with_initialization_script(
+            r#"(function(){
+                var style = document.createElement('style');
+                style.textContent = '@media (prefers-color-scheme: dark) { html { filter: invert(1) hue-rotate(180deg); } img, video, canvas, svg { filter: invert(1) hue-rotate(180deg); } }';
+                document.head.appendChild(style);
+                // Also try to set color-scheme meta
+                var meta = document.querySelector('meta[name="color-scheme"]');
+                if (!meta) {
+                    meta = document.createElement('meta');
+                    meta.name = 'color-scheme';
+                    document.head.appendChild(meta);
+                }
+                meta.content = 'dark light';
+            })()"#,
+        );
+    }
+
     let _webview = {
         use tao::platform::unix::WindowExtUnix;
         use wry::WebViewBuilderExtUnix;
@@ -352,6 +504,9 @@ fn main() -> wry::Result<()> {
         builder.build_gtk(vbox)?
     };
 
+    // #59: Minimize to background on close
+    let minimize_on_close = browser.minimize_to_background.unwrap_or(false);
+
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
@@ -360,7 +515,11 @@ fn main() -> wry::Result<()> {
             ..
         } = event
         {
-            *control_flow = ControlFlow::Exit;
+            if minimize_on_close {
+                window.set_visible(false);
+            } else {
+                *control_flow = ControlFlow::Exit;
+            }
         }
     });
 }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -57,6 +57,26 @@ pub struct Browser {
     pub user_agent: Option<UserAgent>,
     pub permissions: Option<PermissionPolicy>,
     pub url_schemes: Option<Vec<String>>,
+    // #53: Content blocking (ads/trackers)
+    pub content_blocking: Option<bool>,
+    // #60: Block third-party cookies
+    pub block_third_party_cookies: Option<bool>,
+    // #61: Block WebRTC IP leak
+    pub block_webrtc: Option<bool>,
+    // #54: HTTP/HTTPS proxy
+    pub proxy_url: Option<String>,
+    // #55: Page zoom level
+    pub zoom_level: Option<f64>,
+    // #56: Session restore
+    pub restore_session: Option<bool>,
+    pub last_url: Option<String>,
+    // #57: Usage statistics
+    pub launch_count: Option<u64>,
+    pub last_launched: Option<u64>,
+    // #59: Minimize to background on close
+    pub minimize_to_background: Option<bool>,
+    // #62: Auto dark mode
+    pub auto_dark_mode: Option<bool>,
 }
 
 impl Browser {
@@ -79,6 +99,17 @@ impl Browser {
             user_agent: None,
             permissions: None,
             url_schemes: None,
+            content_blocking: None,
+            block_third_party_cookies: None,
+            block_webrtc: None,
+            proxy_url: None,
+            zoom_level: None,
+            restore_session: None,
+            last_url: None,
+            launch_count: None,
+            last_launched: None,
+            minimize_to_background: None,
+            auto_dark_mode: None,
         };
 
         if with_profile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,6 +763,27 @@ pub fn running_webview_app_ids() -> HashSet<String> {
     ids
 }
 
+/// Format a Unix timestamp as a human-readable date/time string.
+pub fn format_timestamp(ts: u64) -> String {
+    use std::time::{Duration, UNIX_EPOCH};
+    let dt = UNIX_EPOCH + Duration::from_secs(ts);
+    match dt.elapsed() {
+        Ok(elapsed) => {
+            let secs = elapsed.as_secs();
+            if secs < 60 {
+                "just now".to_string()
+            } else if secs < 3600 {
+                format!("{}m ago", secs / 60)
+            } else if secs < 86400 {
+                format!("{}h ago", secs / 3600)
+            } else {
+                format!("{}d ago", secs / 86400)
+            }
+        }
+        Err(_) => "unknown".to_string(),
+    }
+}
+
 /// Clear all website data (cookies, cache, storage) for a web app by removing its profile directory.
 /// Returns Ok(()) on success, or an error if removal failed.
 pub fn clear_profile_data(app_id: &str) -> Result<(), std::io::Error> {


### PR DESCRIPTION
## Summary

Implements all 10 remaining low-priority feature issues:

- **#53**: Content blocking — JS injection removes ad-related DOM elements
- **#54**: Proxy config — sets http_proxy/https_proxy env vars before WebContext
- **#55**: Zoom level — configurable CSS zoom property (0.25x-5.0x)
- **#56**: Session restore — IPC-based URL saving, restores on next launch
- **#57**: Usage statistics — launch count and timestamp, shown in editor
- **#58**: Bulk operations — select apps in grid view, bulk delete/export
- **#59**: Minimize to background — window hides on close
- **#60**: Block third-party cookies — JS override
- **#61**: Block WebRTC IP leak — disables RTCPeerConnection
- **#62**: Auto dark mode — CSS filter inversion

## Files Changed (6 files, +599/-10 lines)

| File | Changes |
|------|---------|
| src/browser.rs | 11 new Option fields on Browser struct |
| src/lib.rs | format_timestamp() helper for usage stats display |
| src/bin/dev-heppen-webapps/pages/editor.rs | 10 new fields, 8 message variants, handlers, UI |
| src/bin/dev-heppen-webapps/pages/mod.rs | Bulk mode state, bulk delete/export, usage stats on launch |
| src/bin/webview.rs | JS injection for privacy/zoom/session/dark-mode, proxy env vars, minimize |
| i18n/en/webapps.ftl | 20+ new translation keys |

## Test plan

- [ ] cargo build --release succeeds
- [ ] Verify new toggles in Advanced Settings
- [ ] Test each feature individually

Closes #53, #54, #55, #56, #57, #58, #59, #60, #61, #62